### PR TITLE
feat: Parse meeting notes from documentPanels

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,3 +197,8 @@ The server reads from Granola's cache file at:
 - Verify the absolute path in your Claude config
 - Check Claude Desktop logs for MCP server errors
 - Restart Claude Desktop after config changes
+
+### Meeting notes appear empty in Claude
+- Granola sometimes stores rich notes inside `documentPanels` rather than `notes_plain`
+- This server now reads those panels by default; set `GRANOLA_PARSE_PANELS=0` in the environment to disable
+- Run `python test_real_cache.py` to verify that panel-backed notes produce content


### PR DESCRIPTION
Granola has shifted rich meeting notes into `documentPanels` for recent meetings, causing `notes_plain` and `notes_markdown` to be empty. This change updates the cache parser to fall back to `documentPanels` when the traditional note fields are empty.

## Changes

- Updates `_parse_cache_data` to read `documentPanels` as a content source.
- Adds `_extract_document_panel_content` to traverse the rich JSON structure.
- Hardens tests in `test_server.py` and `test_real_cache.py` to validate both panel-based and `notes_plain` content extraction.
- Adds a `GRANOLA_PARSE_PANELS` environment flag to disable the new behavior for troubleshooting.
- Updates README with troubleshooting info for empty notes.

## Testing

- All tests pass with both synthetic and real cache data
- Validates that recent meetings with panel-backed notes now show proper content instead of being empty
- Maintains backward compatibility with existing `notes_plain` content