### PR TITLE
Add one-click Cursor install button

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,25 @@ An experimental Model Context Protocol (MCP) server for integrating Granola.ai m
 - Python 3.12+
 - [uv](https://docs.astral.sh/uv/) package manager
 - macOS with Granola.ai installed
-- Claude Desktop application
 - Granola cache file at `~/Library/Application Support/Granola/cache-v3.json`
 
-### Installation
+### One-Click Install for Cursor (Recommended)
+
+[![Add Granola MCP to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=granola&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyItLWZyb20iLCJnaXQraHR0cHM6Ly9naXRodWIuY29tL3Byb29mZ2Vpc3QvZ3Jhbm9sYS1haS1tY3Atc2VydmVyIiwiZ3Jhbm9sYS1tY3Atc2VydmVyIl0sImVudiI6e319)
+
+Click the button above to automatically add the Granola MCP server to Cursor.
+
+> **Note:** This requires [uv](https://docs.astral.sh/uv/) to be installed and Granola.ai to be running on macOS.
+
+### Manual Installation (Claude Desktop)
+
+<details>
+<summary>Click to expand manual setup instructions</summary>
 
 1. **Clone the repository to your home directory:**
    ```bash
    cd ~
-   git clone <repository-url>
+   git clone https://github.com/proofgeist/granola-ai-mcp-server
    cd granola-ai-mcp-server
    ```
    
@@ -67,6 +77,8 @@ An experimental Model Context Protocol (MCP) server for integrating Granola.ai m
    # Reopen Claude
    open -a "Claude"
    ```
+
+</details>
 
 ## Available Tools
 


### PR DESCRIPTION
## Summary

Adds a one-click "Add to Cursor" button for easy MCP server installation, following the pattern used by other MCP servers like [gusto-cli](https://github.com/Gusto/gusto-cli).

## Changes

- Added **One-Click Install for Cursor (Recommended)** section with a Cursor deeplink button
- Reorganized manual installation instructions into a collapsible `<details>` section
- Fixed the clone URL to use the actual GitHub repository URL

## How it works

The button uses Cursor's deeplink feature with a base64-encoded MCP configuration:

```json
{
  "command": "uvx",
  "args": ["--from", "git+https://github.com/proofgeist/granola-ai-mcp-server", "granola-mcp-server"],
  "env": {}
}
```

When users click the button, Cursor automatically installs the MCP server using `uvx` directly from GitHub - no manual cloning required.

## Testing

- Verified the button renders correctly on GitHub
- Tested the deeplink URL navigates to Cursor's install page with correct configuration
- Confirmed the MCP server name shows as "granola" in Cursor's settings

## Screenshots

The button appears in the Quick Start section:

[![Add Granola MCP to Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=granola&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyItLWZyb20iLCJnaXQraHR0cHM6Ly9naXRodWIuY29tL3Byb29mZ2Vpc3QvZ3Jhbm9sYS1haS1tY3Atc2VydmVyIiwiZ3Jhbm9sYS1tY3Atc2VydmVyIl0sImVudiI6e319)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added one-click installer option for Cursor as the recommended setup method
  * Expanded manual Claude Desktop installation guide with step-by-step configuration, prerequisites, and restart instructions
  * Introduced comprehensive troubleshooting section covering setup issues, permissions, and verification steps

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->