### PR TITLE
chore: add repo baseline (mise, CLAUDE, smoke)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# CLAUDE.md
+
+## Setup
+mise install
+mise run install
+
+## Run
+uv run granola-mcp-server
+
+## Smoke
+mise run smoke
+
+## Rules
+- Keep changes scoped and reversible.
+- Do not modify local cache files or secrets.
+- Run smoke before commit.

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,9 @@
+[tools]
+python = "3.14"
+node = "24.13.1"
+
+[tasks.install]
+run = "uv sync && npm ci"
+
+[tasks.smoke]
+run = "bash scripts/smoke.sh"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "branches": [
       "main"
     ]
-  }
+  },
+  "scripts": {
+    "smoke": "bash scripts/smoke.sh"
+  },
+  "packageManager": "npm@11.10.0"
 }
-

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+uv sync
+npm ci
+uv run python test_server.py
+uv run python -c "from granola_mcp_server.server import main; print('import_ok')"
+echo "granola smoke passed"


### PR DESCRIPTION
This PR standardizes repo bootstrap and AI-agent workflow:\n\n- adds/normalizes  runtime pinning\n- adds/updates  with repo run/test notes\n- adds  as a deterministic smoke entrypoint\n- aligns package metadata where applicable\n\nValidation:  passes on local machine.